### PR TITLE
implement 2d prefix sums [SATs] for faster algorithmic implementation of epsilon

### DIFF
--- a/finches/benchmarking/benchmark_matrix_scan.py
+++ b/finches/benchmarking/benchmark_matrix_scan.py
@@ -1,0 +1,62 @@
+import time
+
+import numpy as np
+
+from finches.utils.matrix_manipulation import matrix_scan, matrix_scan_legacy
+
+
+def generate_random_matrix(rows, cols):
+    """Generate a random matrix of given dimensions."""
+    return np.random.rand(rows, cols)
+
+
+def benchmark_matrix_scan(
+    w_matrix, window_size, matrix_size, cython=True, legacy=False
+):
+    """Benchmark the matrix_scan function."""
+    # Generate a random matrix
+
+    # Define a null interaction baseline
+    null_interaction_baseline = 0.5
+
+    # Measure the start time
+    start_time = time.perf_counter()
+
+    if cython and not legacy:
+        everything, seq1_indices, seq2_indices = matrix_scan(
+            w_matrix, window_size, null_interaction_baseline
+        )
+    elif cython and legacy:
+        everything, seq1_indices, seq2_indices = matrix_scan_legacy(
+            w_matrix, window_size, null_interaction_baseline
+        )
+
+    # Measure the end time
+    end_time = time.perf_counter()
+
+    # Calculate the elapsed time
+    elapsed_time = end_time - start_time
+
+    print(f"Benchmark Results:")
+    print(f"Matrix Size: {matrix_size}x{matrix_size}")
+    print(f"Window Size: {window_size}")
+    print(f"Output Shape: {everything.shape}")
+    print(f"Elapsed Time: {elapsed_time:.6f} seconds")
+
+    return everything
+
+
+if __name__ == "__main__":
+    # Define parameters for benchmarking
+    window_size = 31
+    matrix_size = 1000  # m*n matrix (1000x1000)
+    w_matrix = generate_random_matrix(matrix_size, matrix_size)
+    # Run the benchmark
+    ev1 = benchmark_matrix_scan(w_matrix, window_size, matrix_size, legacy=False)
+    ev2 = benchmark_matrix_scan(w_matrix, window_size, matrix_size, legacy=True)
+
+    # print(ev1,"\n")
+    # print(ev2)
+    assert np.allclose(ev1, ev2), (
+        "Different results from optimized and non-optimized implementations!"
+    )

--- a/finches/epsilon_calculation.py
+++ b/finches/epsilon_calculation.py
@@ -2,40 +2,39 @@
 Class to build Interation Matrix from Mpipi forcefield By
 
 
-values : Garrett M. Ginell & Alex S. Holehouse 
+values : Garrett M. Ginell & Alex S. Holehouse
 2023-08-06
 """
 
-
 import numpy as np
-from finches.data import forcefield_dependencies
-from finches import parsing_aminoacid_sequences
 
+from finches import epsilon_stateless, parsing_aminoacid_sequences
+from finches.data import forcefield_dependencies
 from finches.utils import matrix_manipulation
-from finches import epsilon_stateless
+
 
 # -------------------------------------------------------------------------------------------------
 class InteractionMatrixConstructor:
-    
-    def __init__(self,
-                 parameters,
-                 sequence_converter=False,
-                 charge_prefactor=None,
-                 null_interaction_baseline=None, 
-                 compute_forcefield_dependencies=False):
-        
+    def __init__(
+        self,
+        parameters,
+        sequence_converter=False,
+        charge_prefactor=None,
+        null_interaction_baseline=None,
+        compute_forcefield_dependencies=False,
+    ):
         """
         The InteractionMatrixConstructor is a class which houses user-facing
         functions for calculating inter-residue interactions. This is appropriate
         if you want more fine-grained control over epsilon-associated calculations.
-        Alternatively, using one of the finches.frontend modules may be an easier 
+        Alternatively, using one of the finches.frontend modules may be an easier
         route if you're just doing "standard" types of analysis.
 
         Philosophically speaking, the goal here is to separate the biophysical
-        model used to determine interaction parameters into a set of classes 
-        housed in finches.forcefields, and then the class InteractionMatrixConstructor       
-        takes one of those models in as initializing input and provides a 
-        standardized way to calculate the same types of interaction properties 
+        model used to determine interaction parameters into a set of classes
+        housed in finches.forcefields, and then the class InteractionMatrixConstructor
+        takes one of those models in as initializing input and provides a
+        standardized way to calculate the same types of interaction properties
         derived from many different biophysical models. In software engineering, this
         is known as an "interface" design pattern.
 
@@ -44,28 +43,28 @@ class InteractionMatrixConstructor:
             # import key modules
             from finches.forcefields.mpipi import Mpipi_model
             from finches.epsilon_calculation import InteractionMatrixConstructor
-            
+
             # Initialize a finches.forcefields.Mpipi.Mpipi_model object
             Mpipi_GGv1_params = Mpipi_model(version = 'Mpipi_GGv1')
 
             # initialize an InteractionMatrixConstructor
             IMC = InteractionMatrixConstructor(parameters = Mpipi_GGv1_params)
 
-        The InteractionMatrixConstructor object (aka IMC) then provides functionality 
-        for calculating inter-residue interactions using the energetics in the 
+        The InteractionMatrixConstructor object (aka IMC) then provides functionality
+        for calculating inter-residue interactions using the energetics in the
         underlying model. Moreover, the IMC object can also then be updated in a
         variety of ways.
-        
+
         Parameters
         -----------
         parameters : finches.forcefield.<model>.<model_object>
-            Instance of one of the forcefield objects found in finches.forcefields 
+            Instance of one of the forcefield objects found in finches.forcefields
             module. This object contains all of the parameters for the model, such
             that the InteractionMatrixConstructor calls on a series of functions
             that a model presents to calculate the associated interactions in
             a consistent way.
 
-            In this way, different interaction models can be distributed but the 
+            In this way, different interaction models can be distributed but the
             same analysis code (using an InteractionMatrixConstructor) can always
             be used.
 
@@ -77,45 +76,45 @@ class InteractionMatrixConstructor:
               a protein list, an RNA list, a DNA list etc. Note that EVERY residue in
               all lists must have a pair-wise interaction parameter calculatable via
               the compute_interaction_parameter() function (described below)
-                        
+
             * parameters.compute_interaction_parameter(r1,r2) : function which takes
-              two valid residues (i.e. any pair from the residues defined in 
+              two valid residues (i.e. any pair from the residues defined in
               ALL_RESIDUES_TYPES) and returns a value that reports on the relative
               preferential interaction between those residues.
 
-            * parameters.CONFIGS: dictionary with some general default 
-              precomputed values for the forcefield, including: 'charge_prefactor' 
+            * parameters.CONFIGS: dictionary with some general default
+              precomputed values for the forcefield, including: 'charge_prefactor'
               and, 'null_interaction_baseline', which will be used if these are
               not explicitly passed into this constructor.
-                      
-        sequence_converter : function 
-            A function that takes in a sequence and converts the sequence to 
-            an alternative sequnence that matches the acceptable residue types of the 
-            parameters object. If no function is provided, a default function that 
-            returns the input sequences is provided. This can be useful if 
+
+        sequence_converter : function
+            A function that takes in a sequence and converts the sequence to
+            an alternative sequnence that matches the acceptable residue types of the
+            parameters object. If no function is provided, a default function that
+            returns the input sequences is provided. This can be useful if
             we need to mask sequences in a certain way.
 
-        charge_prefactor : float 
-            Model-specific value that defines how the charge weighting is scaled. 
-            Charge weighting is implemented in a way that runs oppositely 
-            charged residues are less repulsive for one another than they might 
-            otherwise be, mimicking the fact that charged sidechains can point away 
-            from one another and/or be influenced by pKa shifts. The 
-            charge_prefactor is a scalar which in effect, scales the strength of this 
-            scaling has and typically needs to be tuned on a per forcefield basis. 
+        charge_prefactor : float
+            Model-specific value that defines how the charge weighting is scaled.
+            Charge weighting is implemented in a way that runs oppositely
+            charged residues are less repulsive for one another than they might
+            otherwise be, mimicking the fact that charged sidechains can point away
+            from one another and/or be influenced by pKa shifts. The
+            charge_prefactor is a scalar which in effect, scales the strength of this
+            scaling has and typically needs to be tuned on a per forcefield basis.
             Note that this value must be between 0 and 1.
 
-        null_interaction_baseline : float  
+        null_interaction_baseline : float
             Model-specific threshold to differentiate between attractive and repulsive
             interactions. By default, this baseline is parameterized based on the attractive/
             repulsive interaction associated with a poly(GS) sequence, which we expect
-            to behave as a Gaussian chain, however, we can over-ride the default value. 
-            
+            to behave as a Gaussian chain, however, we can over-ride the default value.
 
-            NOTE -  null_interaction_baseline is specific to the parameter version. 
-                    The null_interaction_baseline is the value used to split matrix. 
-                    This has been built such that this value recapitulates PolyGS for                    
-                    the specific input model being used. Precomputed null_interaction 
+
+            NOTE -  null_interaction_baseline is specific to the parameter version.
+                    The null_interaction_baseline is the value used to split matrix.
+                    This has been built such that this value recapitulates PolyGS for
+                    the specific input model being used. Precomputed null_interaction
                     baseline can be found in the CONFIGS dictionary of the parameters
                     object.
 
@@ -124,10 +123,10 @@ class InteractionMatrixConstructor:
 
                         data.forcefield_dependencies.get_null_interaction_baseline
 
-        compute_forcefield_dependencies : bool 
-            Flag to specify whether to recompute the model-specific 
+        compute_forcefield_dependencies : bool
+            Flag to specify whether to recompute the model-specific
             charge_prefactor and null_interaction_baseline used when computing epsilon if
-            these are not available at runtime. 
+            these are not available at runtime.
 
         """
 
@@ -137,21 +136,25 @@ class InteractionMatrixConstructor:
         try:
             self.valid_residue_groups = parameters.ALL_RESIDUES_TYPES
         except AttributeError:
-            raise AttributeError('Tried to call ALL_RESIDUE_TYPES from the parameters object but no such variable is found. Please ensure the passed forcefield object possesses a .ALL_RESIDUES_TYPES object variable')
+            raise AttributeError(
+                "Tried to call ALL_RESIDUE_TYPES from the parameters object but no such variable is found. Please ensure the passed forcefield object possesses a .ALL_RESIDUES_TYPES object variable"
+            )
 
-        
         # initialize core class variables; we do this here mainly for convenince in the
-        # code, so all the class variables are clearly defined in one place        
-        self.parameters                = None # finches.forcefield.<forcefield_module>.<forcefield_class> object
-        self.sequence_converter        = None # function converts a sequence automatically
-        self.charge_prefactor          = None # prefactor that scales how much charge weighting matters
-        self.null_interaction_baseline = None # fixed value acts as an offset for deliniating attractive/repulsive interactions
-        self.lookup = {}                      # dictionary which provides lookup[r1][r2] => interaction value
+        # code, so all the class variables are clearly defined in one place
+        self.parameters = (
+            None  # finches.forcefield.<forcefield_module>.<forcefield_class> object
+        )
+        self.sequence_converter = None  # function converts a sequence automatically
+        self.charge_prefactor = (
+            None  # prefactor that scales how much charge weighting matters
+        )
+        self.null_interaction_baseline = None  # fixed value acts as an offset for deliniating attractive/repulsive interactions
+        self.lookup = {}  # dictionary which provides lookup[r1][r2] => interaction value
 
-        
         ## Set up sequence converter
         if not sequence_converter:
-            self.sequence_converter = lambda a: a 
+            self.sequence_converter = lambda a: a
         else:
             self.sequence_converter = sequence_converter
 
@@ -163,15 +166,21 @@ class InteractionMatrixConstructor:
         # This is the main function that sets up the self.lookup table and ensures self.parameters maps to
         # a valid object
         self._update_parameters(parameters)
-        
+
         # check null_interaction_baseline
-        if self.null_interaction_baseline == None: 
+        if self.null_interaction_baseline is None:
             try:
-                self.null_interaction_baseline = self.parameters.CONFIGS['null_interaction_baseline']
-            except Exception as e: 
+                self.null_interaction_baseline = self.parameters.CONFIGS[
+                    "null_interaction_baseline"
+                ]
+            except Exception as e:
                 if compute_forcefield_dependencies:
-                    print(f'Recomputing the null_interaction_baseline for {self.parameters.version}...')
-                    self.null_interaction_baseline = forcefield_dependencies.get_null_interaction_baseline(self)
+                    print(
+                        f"Recomputing the null_interaction_baseline for {self.parameters.version}..."
+                    )
+                    self.null_interaction_baseline = (
+                        forcefield_dependencies.get_null_interaction_baseline(self)
+                    )
                 else:
                     print(f'''WARNING: null_interaction_baseline NOT found or defined for the parameter version "{parameters.version}". 
     Update this forcefield model or set compute_forcefield_dependencies = True. 
@@ -179,23 +188,23 @@ class InteractionMatrixConstructor:
 
     To compute a new null_interaction_baseline see: data.forcefield_dependencies.null_interaction_baseline\n''')
 
-        # charge charge_prefactor 
-        if self.charge_prefactor == None: 
-            try:                
-                self.charge_prefactor = self.parameters.CONFIGS['charge_prefactor']
+        # charge charge_prefactor
+        if self.charge_prefactor == None:
+            try:
+                self.charge_prefactor = self.parameters.CONFIGS["charge_prefactor"]
             except Exception as e:
                 print("A charge prefactor must be provided to use charge weighting")
-                raise Exception("A charge prefactor must be provided to use charge weighting and one is not defined in the forcefield CONFIGS dictionary.")
+                raise Exception(
+                    "A charge prefactor must be provided to use charge weighting and one is not defined in the forcefield CONFIGS dictionary."
+                )
 
-
-                    
     ## ................................................................................... ##
     ##
     ##
     def _update_lookup_dict(self, unknown_set_to_zero=False):
         """
         Function which, if called, wipes the previous inter-residue interaction
-        parameters (the 'lookup_dict') and recalculates using the self.parameter 
+        parameters (the 'lookup_dict') and recalculates using the self.parameter
         object, which should be a finches.forcefield.<model>.<model_object> object.
 
         Parameters
@@ -210,7 +219,7 @@ class InteractionMatrixConstructor:
         None
 
         """
-        # make sure all resigroup pairs can be calculated based on passed parameter 
+        # make sure all resigroup pairs can be calculated based on passed parameter
         #  and build reference dictionary
         ## NOTE NEED TO ADD CHECKERS FOR UNFOUND PAIRS ##
 
@@ -219,14 +228,15 @@ class InteractionMatrixConstructor:
         self.lookup = {}
 
         # extract out all residues into a single list. Note the list/set nested operation
-        # ensures valid aa is a non-redundant list. 
-        valid_aa = list(set([res for sublist in self.valid_residue_groups for res in sublist]))
+        # ensures valid aa is a non-redundant list.
+        valid_aa = list(
+            set([res for sublist in self.valid_residue_groups for res in sublist])
+        )
 
         # note this cycles through all possible residue pairs as defined by all of the valid
-        # amino acids in the valid residue groups        
+        # amino acids in the valid residue groups
         for r1 in valid_aa:
-
-            self.lookup[r1] = {}            
+            self.lookup[r1] = {}
             for r2 in valid_aa:
                 # this parameter function (compute_interaction_parameters()) is a required
                 # function in a valid finches.forcefield.
@@ -234,35 +244,37 @@ class InteractionMatrixConstructor:
                 # use a try/except statement to zero out missing pairs IF we
                 # request this to happen
                 try:
-                    self.lookup[r1][r2] = self.parameters.compute_interaction_parameter(r1,r2)[0]
+                    self.lookup[r1][r2] = self.parameters.compute_interaction_parameter(
+                        r1, r2
+                    )[0]
 
                 # take a gamble on error handling that an invalid parameter will trigger
                 # a KeyError, and handle it IF unknown_set_to_zero is True.
                 except KeyError as e:
                     if unknown_set_to_zero:
-
                         # we may remove this at some point but for now we're going to print
                         # the raw error before printing the specific pair being set to zero
                         # as well.
                         print(e)
-                        print(f'WARNING: Unknown residue pair {r1}-{r2}, setting to zero.')
+                        print(
+                            f"WARNING: Unknown residue pair {r1}-{r2}, setting to zero."
+                        )
                         self.lookup[r1][r2] = 0.0
                     else:
-                        raise Exception(f'ERROR: {e} for {r1} and {r2}.')
-
+                        raise Exception(f"ERROR: {e} for {r1} and {r2}.")
 
     ## ................................................................................... ##
     ##
-    ##                
+    ##
     def _update_parameters(self, new_parameters):
         """
 
         Function which wipes the current parameters in the model and updates with a
-        new set. This 
+        new set. This
 
         This does NOT update
 
-        self.charge_prefactor 
+        self.charge_prefactor
         self.sequence_converter
         self.null_interaction_baseline
 
@@ -271,7 +283,7 @@ class InteractionMatrixConstructor:
         Parameters
         ------------
         new_parameters : finches.forcefield.<model>.<model_object>
-            Instance of one of the forcefield objects found in finches.forcefields 
+            Instance of one of the forcefield objects found in finches.forcefields
             module. This object contains all of the parameters for the model, such
             that the InteractionMatrixConstructor calls on a series of functions
             that a model presents to calculate the associated interactions in
@@ -280,29 +292,28 @@ class InteractionMatrixConstructor:
         Returns
         ----------
         None
-            No return but updates this object appropriately        
+            No return but updates this object appropriately
 
         """
 
         # update the parameters object
         self.parameters = new_parameters
 
-        # update the valid residue groups 
-        self.valid_residue_groups = new_parameters.ALL_RESIDUES_TYPES 
+        # update the valid residue groups
+        self.valid_residue_groups = new_parameters.ALL_RESIDUES_TYPES
 
         # update the valid amino acid interaction lookup table
         # based on the updated self.valid_residue_group and the
         # updated parameters object
         self._update_lookup_dict()
 
-
     ## ................................................................................... ##
     ##
-    ##                        
+    ##
     def _check_sequence(self, sequence):
         """
-        Function that checks that passed sequence contains (1) 
-        Residues found in ONE of the self.valid_residue_groups 
+        Function that checks that passed sequence contains (1)
+        Residues found in ONE of the self.valid_residue_groups
         and (2) a single sequene ONLY has residues that originate
         from a single residue group.
 
@@ -314,14 +325,11 @@ class InteractionMatrixConstructor:
         Returns
         ----------------
         None
-        
+
         """
 
-        
-        
         found_lists = set()
         unique_residues = set(sequence)
-
 
         # this keeps tracks of how many DIFFERENT residue groups
         # we found residue in sequence that intersected with. It SHOULD
@@ -331,7 +339,6 @@ class InteractionMatrixConstructor:
         # keep track of how many of the uniqu_residues we've seen
         hits = 0
         for residue_group in self.valid_residue_groups:
-
             # find amino acids in both the unique_residue set and
             # in the current residue_group
             common_values = unique_residues.intersection(residue_group)
@@ -340,17 +347,19 @@ class InteractionMatrixConstructor:
             if common_values:
                 residue_group_count += 1
                 hits = hits + len(common_values)
-                
+
         if len(unique_residues) > 0:
             if residue_group_count > 1:
-                raise Exception(f'INVALID SEQUENCE - input sequence below contains a mix of valid residues from different groups: \n {sequence}')
+                raise Exception(
+                    f"INVALID SEQUENCE - input sequence below contains a mix of valid residues from different groups: \n {sequence}"
+                )
             elif hits < len(unique_residues):
-                raise Exception(f'INVALID SEQUENCE - unknow residue found in input sequence below: \n {sequence}')
+                raise Exception(
+                    f"INVALID SEQUENCE - unknow residue found in input sequence below: \n {sequence}"
+                )
         else:
-            raise Exception(f'INVALID SEQUENCE - no input sequence passed')
+            raise Exception(f"INVALID SEQUENCE - no input sequence passed")
 
-
-        
     ## ------------------------------------------------------------------------------
     ##
     def get_converted_sequence(self, sequence):
@@ -363,12 +372,12 @@ class InteractionMatrixConstructor:
         ----------
         sequence : str
             Amino acid sequence of interest
-        
+
         Returns
         ----------
         str
             converted sequence from self.sequence_converter(sequence)
-        
+
         """
 
         # convert if appropriate
@@ -379,9 +388,8 @@ class InteractionMatrixConstructor:
 
         # check sequence is valid
         self._check_sequence(outseq)
-        
-        return outseq
 
+        return outseq
 
     ######################################################################
     ##                                                                  ##
@@ -394,15 +402,14 @@ class InteractionMatrixConstructor:
     ## ------------------------------------------------------------------------------
     ##
     def calculate_pairwise_homotypic_matrix(self, sequence, convert_to_custom=True):
-        
         """
         Function that calculates the homotypic matrix WITHOUT any weighting factors.
-        
+
         Note - the matrix here is the raw unsliding-windowed matrix so will be
         len(seq) by len(seq) long. For visualizing local regions of inter-residue
         interaction use the calculate_sliding_epsilon() function.
-        
-        In reality, you should just do all pairwise-residues ONCE 
+
+        In reality, you should just do all pairwise-residues ONCE
         at the start and then look 'em up, but this code below does the
         dynamic non-redundant on-the-fly calculation of unique pairwise
         residues.
@@ -419,12 +426,15 @@ class InteractionMatrixConstructor:
             that negative values are attractive and positive are repulsive!
 
         """
-        return self.calculate_pairwise_heterotypic_matrix(sequence, sequence, convert_to_custom=convert_to_custom)
-        
+        return self.calculate_pairwise_heterotypic_matrix(
+            sequence, sequence, convert_to_custom=convert_to_custom
+        )
+
     ## ------------------------------------------------------------------------------
-    ## 
-    def calculate_pairwise_heterotypic_matrix(self, sequence1, sequence2, convert_to_custom=True, use_cython=True):
-        
+    ##
+    def calculate_pairwise_heterotypic_matrix(
+        self, sequence1, sequence2, convert_to_custom=True, use_cython=True
+    ):
         """
         This function takes two sequences and returns a sequence1 x sequence2
         2D np.array.
@@ -432,14 +442,14 @@ class InteractionMatrixConstructor:
         len(seq) by len(seq) long. For visualizing local regions of inter-residue
         interaction use the calculate_sliding_epsilon() function.
 
-        In reality, you should just do all pairwise-residues ONCE 
+        In reality, you should just do all pairwise-residues ONCE
         at the start and then look 'em up, but this code below does the
         dynamic non-redundant on-the-fly calculation of unique pairwise
         residues.
 
         Note we default to using a Cython implementation which is 3.5x faster
-        than the pure Python implementation. For now we're leaving in the 
-        option to fall back to a Python implementation but that may be 
+        than the pure Python implementation. For now we're leaving in the
+        option to fall back to a Python implementation but that may be
         removed at some point...
 
         Parameters
@@ -453,13 +463,13 @@ class InteractionMatrixConstructor:
         use_cython : bool
             Flag to select whether to use the cythonized version of the code
             or the Python version. The cythonized version reduces the time
-            to about 5-10% of the Python version. 
+            to about 5-10% of the Python version.
 
         Returns
         ------------------
         np.array
-            Returns an (len(s1) x len(s2)) matrix with pairwise interactions; 
-            recall that negative values are attractive and positive are 
+            Returns an (len(s1) x len(s2)) matrix with pairwise interactions;
+            recall that negative values are attractive and positive are
             repulsive!
 
         """
@@ -475,34 +485,33 @@ class InteractionMatrixConstructor:
 
         if use_cython:
             return matrix_manipulation.dict2matrix(sequence1, sequence2, self.lookup)
-            
-        else:                
+
+        else:
             matrix = []
             for r1 in sequence1:
                 tmp = []
-            
-                for r2 in sequence2:                
+
+                for r2 in sequence2:
                     tmp.append(self.lookup[r1][r2])
                 matrix.append(tmp)
-            
+
             return np.array(matrix)
 
-
-    
     ## ------------------------------------------------------------------------------
-    ## 
-    def calculate_weighted_pairwise_matrix(self,
-                                           sequence1,
-                                           sequence2,
-                                           convert_to_custom=True, 
-                                           charge_prefactor=None,
-                                           use_charge_weighting=True,
-                                           use_aliphatic_weighting=True,
-                                           use_cython=True):
-        
+    ##
+    def calculate_weighted_pairwise_matrix(
+        self,
+        sequence1,
+        sequence2,
+        convert_to_custom=True,
+        charge_prefactor=None,
+        use_charge_weighting=True,
+        use_aliphatic_weighting=True,
+        use_cython=True,
+    ):
         """
         Calculate heterotypic matrix and then weight the matrix based on
-        the various flags defined here.  
+        the various flags defined here.
 
         Parameters
         ---------------
@@ -511,52 +520,56 @@ class InteractionMatrixConstructor:
 
         sequence2 : str
             Amino acid sequence of interest
-                                                                                     
-        
-        prefactor : float 
-            Model specific value to plug into the local charge weighting of 
-            the matrix 
+
+
+        prefactor : float
+            Model specific value to plug into the local charge weighting of
+            the matrix
 
         use_charge_weighting : bool
-            Flag to select whether weight the matrix by local sequence charge 
+            Flag to select whether weight the matrix by local sequence charge
 
         use_aliphatic_weighting : bool
-            Flag to select whether weight the matrix by local patches of aliphatic 
+            Flag to select whether weight the matrix by local patches of aliphatic
             residues
 
         use_cython : bool
             Flag to select whether to use the cythonized version of the code
             or the python version. The cythonized version is reduces the time
-            to about 5-10% of the python version. 
+            to about 5-10% of the python version.
 
         Returns
         ------------------
         np.array
             Returns an (n x n) matrix with pairwise interactions; recall
-            that negative values are attractive and positive are repulsive, 
-            this matrix is weighted by local sequence context of the two 
+            that negative values are attractive and positive are repulsive,
+            this matrix is weighted by local sequence context of the two
             inputed sequences.
 
         """
-        
+
         # compute matrix - note if s1 and s2 are the same that's fine
-        matrix = self.calculate_pairwise_heterotypic_matrix(sequence1, sequence2, convert_to_custom=convert_to_custom, use_cython=use_cython)
+        matrix = self.calculate_pairwise_heterotypic_matrix(
+            sequence1,
+            sequence2,
+            convert_to_custom=convert_to_custom,
+            use_cython=use_cython,
+        )
 
         # weight the matrix by local sequence charge
         if use_charge_weighting:
-
             if charge_prefactor == None:
-                charge_prefactor = self.charge_prefactor 
+                charge_prefactor = self.charge_prefactor
 
             # calculate attractive and repulsive masks. Note as of 2024-04-07 we ONLY populate the repulsive mask, so the
             # attractive matrix (first element here) is returned to _ so we just ignore i.
-            (_, repulsive_mask) = parsing_aminoacid_sequences.get_charge_weighted_mask(sequence1, sequence2)
-            
-            np.set_printoptions(threshold=np.inf)
-            
-                  
-            try:
+            (_, repulsive_mask) = parsing_aminoacid_sequences.get_charge_weighted_mask(
+                sequence1, sequence2
+            )
 
+            np.set_printoptions(threshold=np.inf)
+
+            try:
                 # for the matrix*w_mask calculation, MOST elements in that w_mask array
                 # are zero, so most values get zeroed out other than charge residues. Then
                 # multiplying by the charge_prefactor which is a scalar gives you a forcefield
@@ -564,7 +577,7 @@ class InteractionMatrixConstructor:
                 # the actual matrix to give you a weighted matrix
 
                 # we ADD the attractive matrix, so negative values become more negative
-                
+
                 # NOTE that one implementation split the charge weighting into attractive
                 # and repulsive components but this turned out to be suboptimal for charge,
                 # however we're leaving the code here for other types of weighting in the
@@ -573,7 +586,7 @@ class InteractionMatrixConstructor:
 
                 # we SUBSTRACT the repulsive matrix, so positive numbers become smaller
                 # (but still positive if charge_prefactor is < 1)
-                w_matrix = matrix - (matrix*repulsive_mask*charge_prefactor)
+                w_matrix = matrix - (matrix * repulsive_mask * charge_prefactor)
 
                 """
                 print('Repulsive Mask')
@@ -585,23 +598,26 @@ class InteractionMatrixConstructor:
                 print('delta')
                 print(matrix - w_matrix)
                 """
-                
+
             except Exception as e:
                 print(e)
-                raise Exception('Possible issue: INVALID charge_prefactor, check to ensure self.charge_prefactor is defined.')
+                raise Exception(
+                    "Possible issue: INVALID charge_prefactor, check to ensure self.charge_prefactor is defined."
+                )
                 print(e)
         else:
             w_matrix = matrix
 
         # weight the matrix by local patches of aliphatic residues
         if use_aliphatic_weighting:
-            w_ali_mask = parsing_aminoacid_sequences.get_aliphatic_weighted_mask(sequence1, sequence2)
-            w_matrix = w_matrix*w_ali_mask
+            w_ali_mask = parsing_aminoacid_sequences.get_aliphatic_weighted_mask(
+                sequence1, sequence2
+            )
+            w_matrix = w_matrix * w_ali_mask
 
         # note that additional weights or corrections could be added here as needed
 
         return w_matrix
-
 
     ######################################################################
     ##                                                                  ##
@@ -611,11 +627,13 @@ class InteractionMatrixConstructor:
     ##                                                                  ##
     ######################################################################
 
-    def calculate_epsilon_vectors(self,
-                            sequence1,
-                            sequence2,
-                            use_charge_weighting=True,
-                            use_aliphatic_weighting=True):
+    def calculate_epsilon_vectors(
+        self,
+        sequence1,
+        sequence2,
+        use_charge_weighting=True,
+        use_aliphatic_weighting=True,
+    ):
         """
         Function that returns the attractive and repulsive epsilon vectors for
         the two sequences passed.
@@ -631,40 +649,43 @@ class InteractionMatrixConstructor:
             Second sequence to compare
 
         use_charge_weighting : bool
-            Flag to select whether weight the matrix by local sequence charge 
+            Flag to select whether weight the matrix by local sequence charge
 
         use_aliphatic_weighting : bool
-            Flag to select whether weight the matrix by local patches of 
+            Flag to select whether weight the matrix by local patches of
             aliphatic residues
 
         Returns
         ---------------
         tuple
             Returns a tuple of two lists where element 1 is the attractive
-            vector and element 2 is the repulsive vector. 
-       
+            vector and element 2 is the repulsive vector.
+
 
         """
 
         # note this runs charge_preactor and null_interaction_baseline
         # as null which means the default values associated with this
         # object will be used
-        return epsilon_stateless.get_sequence_epsilon_vectors(sequence1,
-                                                              sequence2,
-                                                              self,
-                                                              use_charge_weighting=use_charge_weighting,
-                                                              use_aliphatic_weighting=use_aliphatic_weighting)
+        return epsilon_stateless.get_sequence_epsilon_vectors(
+            sequence1,
+            sequence2,
+            self,
+            use_charge_weighting=use_charge_weighting,
+            use_aliphatic_weighting=use_aliphatic_weighting,
+        )
 
     ## ------------------------------------------------------------------------------
-    ## 
-    def calculate_epsilon_value(self,
-                          sequence1,
-                          sequence2,
-                          use_charge_weighting=True,
-                          use_aliphatic_weighting=True):
-
+    ##
+    def calculate_epsilon_value(
+        self,
+        sequence1,
+        sequence2,
+        use_charge_weighting=True,
+        use_aliphatic_weighting=True,
+    ):
         """
-        Function that returns the overall epsilon value associated with a 
+        Function that returns the overall epsilon value associated with a
         pair of sequences, as calculated using this
         This is a wrapper around the stateless get_sequence_epsilon_value().
 
@@ -677,38 +698,42 @@ class InteractionMatrixConstructor:
             Second sequence to compare
 
         use_charge_weighting : bool
-            Flag to select whether weight the matrix by local sequence charge 
+            Flag to select whether weight the matrix by local sequence charge
 
         use_aliphatic_weighting : bool
-            Flag to select whether weight the matrix by local patches of 
+            Flag to select whether weight the matrix by local patches of
             aliphatic residues
 
         Returns
         ---------------
         float
             Single value reporting on the average sequence:sequence interaction
-            
+
 
         """
-            
+
         # note this runs charge_prefactor and null_interaction_baseline
         # as null which means the default values associated with this
         # object will be used
-        return epsilon_stateless.get_sequence_epsilon_value(sequence1,
-                                          sequence2,
-                                          self,
-                                          use_charge_weighting=use_charge_weighting,
-                                          use_aliphatic_weighting=use_aliphatic_weighting)
+        return epsilon_stateless.get_sequence_epsilon_value(
+            sequence1,
+            sequence2,
+            self,
+            use_charge_weighting=use_charge_weighting,
+            use_aliphatic_weighting=use_aliphatic_weighting,
+        )
 
     ## ------------------------------------------------------------------------------
-    ## 
-    def calculate_sliding_epsilon(self,
-                                  sequence1,
-                                  sequence2,
-                                  window_size=31,
-                                  use_charge_weighting=True,
-                                  use_aliphatic_weighting=True,
-                                  use_cython=True):
+    ##
+    def calculate_sliding_epsilon(
+        self,
+        sequence1,
+        sequence2,
+        window_size=31,
+        use_charge_weighting=True,
+        use_aliphatic_weighting=True,
+        use_cython=True,
+    ):
         """
         Function that returns the sliding epsilon value associated with a
         pair of sequences, as calculated using this object.
@@ -733,7 +758,7 @@ class InteractionMatrixConstructor:
             plt.imshow(B[0], extent=[B[1][0], B[1][-1], B[2][0], B[2][-1]], aspect='auto', vmax=4, vmin=-4, cmap='seismic', origin='lower')
 
         A few important points here:
-        
+
         1) setting aspect='auto' is important to ensure the matrix is plotted
         with the correct aspect ratio.
 
@@ -745,7 +770,7 @@ class InteractionMatrixConstructor:
         with the correct orientation (i.e. 0,0 is in the lower left corner)
 
         4) the extent=[B[1][0], B[1][-1], B[2][0], B[2][-1]] is important to
-        ensure the matrix is plotted with the correct sequence indices. 
+        ensure the matrix is plotted with the correct sequence indices.
 
 
         Parameters
@@ -770,7 +795,7 @@ class InteractionMatrixConstructor:
         use_cython : bool
             Flag to select whether to use the cythonized version of the code
             or the python version. The cythonized version is reduces the time
-            to about 5-10% of the python version. 
+            to about 5-10% of the python version.
 
         Returns
         ---------------
@@ -807,31 +832,41 @@ class InteractionMatrixConstructor:
                 Epsilon value for the matrix
 
             """
-            attractive_matrix, repulsive_matrix = epsilon_stateless.get_attractive_repulsive_matrices(in_matrix, self.null_interaction_baseline)
+            attractive_matrix, repulsive_matrix = (
+                epsilon_stateless.get_attractive_repulsive_matrices(
+                    in_matrix, self.null_interaction_baseline
+                )
+            )
 
             attractive_matrix = attractive_matrix - self.null_interaction_baseline
-            repulsive_matrix  = repulsive_matrix  - self.null_interaction_baseline
+            repulsive_matrix = repulsive_matrix - self.null_interaction_baseline
 
-        
-            return np.sum(np.mean(attractive_matrix, axis=1)) + np.sum(np.mean(repulsive_matrix, axis=1))
+            return np.sum(np.mean(attractive_matrix, axis=1)) + np.sum(
+                np.mean(repulsive_matrix, axis=1)
+            )
+
         # -----------------------------------------------------
 
         # check that windowsize is odd, and if not make it odd
         if window_size % 2 == 0:
-            print(f"Warning: window size is even, rounding up to next odd number {window_size+1}")
+            print(
+                f"Warning: window size is even, rounding up to next odd number {window_size + 1}"
+            )
             window_size = window_size + 1
-                
-        
+
         # calculate weight pairwise matrix
-        w_matrix = self.calculate_weighted_pairwise_matrix(sequence1,
-                                                           sequence2,
-                                                           use_charge_weighting=use_charge_weighting,
-                                                           use_aliphatic_weighting=use_aliphatic_weighting)
+        w_matrix = self.calculate_weighted_pairwise_matrix(
+            sequence1,
+            sequence2,
+            use_charge_weighting=use_charge_weighting,
+            use_aliphatic_weighting=use_aliphatic_weighting,
+        )
 
         # default to cython version, which is MUCH faster
         if use_cython:
-            return  matrix_manipulation.matrix_scan(w_matrix, window_size, self.null_interaction_baseline)
-                                                        
+            return matrix_manipulation.matrix_scan(
+                w_matrix, window_size, self.null_interaction_baseline
+            )
 
         # get dimensions of matrix
         l1 = w_matrix.shape[0]
@@ -839,35 +874,36 @@ class InteractionMatrixConstructor:
 
         # check for window size larger than matrix size
         if l1 < window_size or l2 < window_size:
-            raise Exception('Window size is larger than matrix size, cannot calculate sliding epsilon')
+            raise Exception(
+                "Window size is larger than matrix size, cannot calculate sliding epsilon"
+            )
 
-        
-        # calculate sliding epsilon for all possible intermolecular windows. 
+        # calculate sliding epsilon for all possible intermolecular windows.
         everything = []
-        for i in range(0,(l1-window_size)+1):
+        for i in range(0, (l1 - window_size) + 1):
             tmp = []
-            for j in range(0, (l2-window_size)+1):        
-                tmp.append(__matrix2eps(w_matrix[i:i+window_size,j:j+window_size]))
+            for j in range(0, (l2 - window_size) + 1):
+                tmp.append(
+                    __matrix2eps(w_matrix[i : i + window_size, j : j + window_size])
+                )
 
             everything.append(tmp)
 
         everything = np.array(everything)
-            
+
         # finally, determine indices for sequence1 - add 1 to return indices
-        # in protein numbering instead of python numbering. 
-        start = int((window_size-1)/2) + 1
-        end   = (l1 - start) + 1
-        seq1_indices = np.arange(start,end+1)
+        # in protein numbering instead of python numbering.
+        start = int((window_size - 1) / 2) + 1
+        end = (l1 - start) + 1
+        seq1_indices = np.arange(start, end + 1)
 
         # and sequence2
-        start = int((window_size-1)/2) + 1
-        end   = (l2 - start) + 1
-        seq2_indices = np.arange(start,end+1)
+        start = int((window_size - 1) / 2) + 1
+        end = (l2 - start) + 1
+        seq2_indices = np.arange(start, end + 1)
 
         # make sure everything is hunky dory...
         assert len(seq1_indices) == everything.shape[0]
         assert len(seq2_indices) == everything.shape[1]
-        
-                
-        return (everything, seq2_indices, seq1_indices)
 
+        return (everything, seq2_indices, seq1_indices)

--- a/finches/tests/test_FH_diagrams.py
+++ b/finches/tests/test_FH_diagrams.py
@@ -1,18 +1,18 @@
-import pytest
-#import un
-
 import pandas as pd
+import pytest
 
-import finches 
-
-from finches.forcefields.mpipi import mpipi_model
-from finches.forcefields.calvados import calvados_model
+import finches
 from finches import epsilon_calculation
+from finches.forcefields.calvados import calvados_model
+from finches.forcefields.mpipi import Mpipi_model
 
-from ..test_data.test_sequences import test_sequences, t0
+from ..test_data.test_sequences import t0, test_sequences
+
+# import un
+
 
 # test are done in the context with the mPiPi_GGv1 model
-L_model = mPiPi_model('mPiPi_GGv1')
+L_model = Mpipi_model("mPiPi_GGv1")
 X_local = epsilon_calculation.Interaction_Matrix_Constructor(L_model)
 
 ############################################################################################
@@ -23,9 +23,9 @@ X_local = epsilon_calculation.Interaction_Matrix_Constructor(L_model)
 ##                                                                                        ##
 ############################################################################################
 
+
 # ..........................................................................................
 #
 #
 def build_DIELECTRIC_dependent_phase_diagrams():
-    pass 
-
+    pass

--- a/finches/tests/test_epsilon_calculation.py
+++ b/finches/tests/test_epsilon_calculation.py
@@ -1,18 +1,18 @@
-import pytest
-#import un
-
 import pandas as pd
+import pytest
 
-import finches 
-
-from finches.forcefields.mpipi import mpipi_model
-from finches.forcefields.calvados import calvados_model
+import finches
 from finches import epsilon_calculation
+from finches.forcefields.calvados import calvados_model
+from finches.forcefields.mpipi import Mpipi_model
 
-from .test_data.test_sequences import test_sequences, t0
+from .test_data.test_sequences import t0, test_sequences
+
+# import un
+
 
 # test are done in the context with the mPiPi_GGv1 model
-L_model = mpipi_model('mPiPi_GGv1')
+L_model = mpipi_model("mPiPi_GGv1")
 X_local = epsilon_calculation.Interaction_Matrix_Constructor(L_model)
 
 import numpy as np
@@ -25,55 +25,68 @@ import numpy as np
 ##                                                                                        ##
 ############################################################################################
 
+
 # ..........................................................................................
 #
 #
 def test_Interaction_Matrix_Constructor():
     pass
 
+
 # ..........................................................................................
 #
 #
 def test_calculate_pairwise_homotypic_matrix():
-    TRUE_matrixes = np.load('test_data/test_mPiPi_GGv1_homotypic_matrix.npz', allow_pickle=True)
+    TRUE_matrixes = np.load(
+        "test_data/test_mPiPi_GGv1_homotypic_matrix.npz", allow_pickle=True
+    )
 
     for i, t in enumerate(test_sequences):
         test_array = X_local.calculate_pairwise_homotypic_matrix(t)
 
         # expect this file to match precomputed homotypic matrix
-        assert np.allclose(test_array, TRUE_matrixes['arr_0'][i])
+        assert np.allclose(test_array, TRUE_matrixes["arr_0"][i])
+
 
 # ..........................................................................................
 #
 #
 def test_calculate_pairwise_heterotypic_matrix():
-    TRUE_matrixes = np.load('test_data/test_mPiPi_GGv1_heterotypic_matrix.npz', allow_pickle=True)
+    TRUE_matrixes = np.load(
+        "test_data/test_mPiPi_GGv1_heterotypic_matrix.npz", allow_pickle=True
+    )
 
     for i, t in test_sequences:
-        test_array = X_local.calculate_pairwise_heterotypic_matrix(t,t0)
+        test_array = X_local.calculate_pairwise_heterotypic_matrix(t, t0)
 
         # expect this file to match precomputed heterotypic matrix
-        assert np.allclose(test_array, TRUE_matrixes['arr_0'][i])
+        assert np.allclose(test_array, TRUE_matrixes["arr_0"][i])
+
 
 # ..........................................................................................
 #
 #
 def test_calculate_weighted_pairwise_matrix():
-    TRUE_matrixes = np.load('test_data/test_mPiPi_GGv1_weighted_matrix.npz', allow_pickle=True)
+    TRUE_matrixes = np.load(
+        "test_data/test_mPiPi_GGv1_weighted_matrix.npz", allow_pickle=True
+    )
 
     for i, t in test_sequences:
-
         # test defaults
-        test_array = X_local.calculate_weighted_pairwise_matrix(t,t0)
-        assert np.allclose(test_array, TRUE_matrixes['DEFAULT'][i])
+        test_array = X_local.calculate_weighted_pairwise_matrix(t, t0)
+        assert np.allclose(test_array, TRUE_matrixes["DEFAULT"][i])
 
         # test NO CHARGE weighting
-        test_array = X_local.calculate_weighted_pairwise_matrix(t,t0, use_charge_weighting=False)
-        assert np.allclose(test_array, TRUE_matrixes['NOCHARGE'][i])
+        test_array = X_local.calculate_weighted_pairwise_matrix(
+            t, t0, use_charge_weighting=False
+        )
+        assert np.allclose(test_array, TRUE_matrixes["NOCHARGE"][i])
 
         # test NO ALIPHATICS weighting
-        test_array = X_local.calculate_weighted_pairwise_matrix(t,t0, use_aliphatic_weighting=False)
-        assert np.allclose(test_array, TRUE_matrixes['NOALIPHATICS'][i])
+        test_array = X_local.calculate_weighted_pairwise_matrix(
+            t, t0, use_aliphatic_weighting=False
+        )
+        assert np.allclose(test_array, TRUE_matrixes["NOALIPHATICS"][i])
 
 
 ############################################################################################
@@ -84,57 +97,65 @@ def test_calculate_weighted_pairwise_matrix():
 ##                                                                                        ##
 ############################################################################################
 
+
 # ..........................................................................................
 #
 #
 def test_get_attractive_repulsive_matrixes():
-    TRUE_matrixes = np.load('test_data/test_matrix_manipulation.npz', allow_pickle=True)
+    TRUE_matrixes = np.load("test_data/test_matrix_manipulation.npz", allow_pickle=True)
 
     # compare the heterotypic DEFAULT matrix of test1:t0
-    test_matrix = TRUE_matrixes['test_matrix'] 
-    TRUEattractive_matrix = TRUE_matrixes['attractive_repulsive_matrixes'][0]
-    TRUErepulsive_matrix = TRUE_matrixes['attractive_repulsive_matrixes'][1]
+    test_matrix = TRUE_matrixes["test_matrix"]
+    TRUEattractive_matrix = TRUE_matrixes["attractive_repulsive_matrixes"][0]
+    TRUErepulsive_matrix = TRUE_matrixes["attractive_repulsive_matrixes"][1]
 
-    attractive_matrix, repulsive_matrix = epsilon_calculation.get_attractive_repulsive_matrixes(test_matrix,-0.15)
+    attractive_matrix, repulsive_matrix = (
+        epsilon_calculation.get_attractive_repulsive_matrixes(test_matrix, -0.15)
+    )
 
-    assert np.allclose(attractive_matrix, TRUEattractive_matrix) 
-    assert np.allclose(repulsive_matrix, TRUErepulsive_matrix) 
+    assert np.allclose(attractive_matrix, TRUEattractive_matrix)
+    assert np.allclose(repulsive_matrix, TRUErepulsive_matrix)
+
 
 # ..........................................................................................
 #
 #
 def test_mask_matrix():
-    TRUE_matrixes = np.load('test_data/test_matrix_manipulation.npz', allow_pickle=True)
+    TRUE_matrixes = np.load("test_data/test_matrix_manipulation.npz", allow_pickle=True)
 
     # compare the heterotypic DEFAULT matrix of test1:t0
-    test_matrix = TRUE_matrixes['test_matrix'] 
-    mask = TRUE_matrixes['bionary_mask']
-    TRUE_masked_matrix = TRUE_matrixes['masked_matrix']
+    test_matrix = TRUE_matrixes["test_matrix"]
+    mask = TRUE_matrixes["bionary_mask"]
+    TRUE_masked_matrix = TRUE_matrixes["masked_matrix"]
 
-    # check masking 
+    # check masking
     test_masked_matrix = epsilon_calculation.masked_matrix(test_matrix, mask)
     assert np.allclose(test_masked_matrix, TRUE_masked_matrix)
 
     # check inpropper mask size
-    with pytest.raises(Exception, match='column_mask and matrix are not the same shape'):
-        epsilon_calculation.masked_matrix(test_matrix, np.array([0,0,0,0]))
+    with pytest.raises(
+        Exception, match="column_mask and matrix are not the same shape"
+    ):
+        epsilon_calculation.masked_matrix(test_matrix, np.array([0, 0, 0, 0]))
+
 
 # ..........................................................................................
 #
 #
 def test_flatten_matrix_to_vector():
-    TRUE_matrixes = np.load('test_data/test_matrix_manipulation.npz', allow_pickle=True)
+    TRUE_matrixes = np.load("test_data/test_matrix_manipulation.npz", allow_pickle=True)
 
     # compare vectors to truth
-    test_matrix = TRUE_matrixes['test_matrix'] 
-    TRUE_vector0 = TRUE_matrixes['flattened_vector'][0]
-    TRUE_vector1 = TRUE_matrixes['flattened_vector'][1]
+    test_matrix = TRUE_matrixes["test_matrix"]
+    TRUE_vector0 = TRUE_matrixes["flattened_vector"][0]
+    TRUE_vector1 = TRUE_matrixes["flattened_vector"][1]
 
     vector_o0 = epsilon_calculation.flatten_matrix_to_vector(test_matrix, orientation=0)
     vector_o1 = epsilon_calculation.flatten_matrix_to_vector(test_matrix, orientation=1)
 
-    assert np.allclose(vector_o0, TRUE_vector0) 
-    assert np.allclose(vector_o1, TRUE_vector1) 
+    assert np.allclose(vector_o0, TRUE_vector0)
+    assert np.allclose(vector_o1, TRUE_vector1)
+
 
 ############################################################################################
 ##                                                                                        ##
@@ -144,43 +165,53 @@ def test_flatten_matrix_to_vector():
 ##                                                                                        ##
 ############################################################################################
 
+
 # ..........................................................................................
 #
 #
 def test_get_sequence_epsilon_vectors():
-    TRUE_matrixes = np.load('test_data/mPiPi_GGv1_seq_epsilon_and_vectors.npz', allow_pickle=True)
+    TRUE_matrixes = np.load(
+        "test_data/mPiPi_GGv1_seq_epsilon_and_vectors.npz", allow_pickle=True
+    )
 
-    # test t0 with test1 and t0 
-    names = ['t', 't0']
+    # test t0 with test1 and t0
+    names = ["t", "t0"]
     for i, t in enumerate([test_sequences[1], t0]):
-        
-        n = names[i] 
+        n = names[i]
 
         # compare vectors to truth default
-        [attractive_vector, repulsive_vector] = all_manipulated[f'{n}_t0_NOWEIGHTING']
-        TESTattractive_vector, TESTrepulsive_vector = epsilon_calculation.get_sequence_epsilon_vectors(t,t0,X_local)
-        assert np.allclose(TESTattractive_vector, attractive_vector) 
-        assert np.allclose(TESTrepulsive_vector, repulsive_vector) 
+        [attractive_vector, repulsive_vector] = all_manipulated[f"{n}_t0_NOWEIGHTING"]
+        TESTattractive_vector, TESTrepulsive_vector = (
+            epsilon_calculation.get_sequence_epsilon_vectors(t, t0, X_local)
+        )
+        assert np.allclose(TESTattractive_vector, attractive_vector)
+        assert np.allclose(TESTrepulsive_vector, repulsive_vector)
 
-        # compare vectors instance with passed baseline 
-        [attractive_vector, repulsive_vector] = all_manipulated[f'{n}_t0_prefactor_baseline']
-        TESTattractive_vector, TESTrepulsive_vector = epsilon_calculation.get_sequence_epsilon_vectors(t,t0,X_local,
-                                                                            prefactor=0.25,
-                                                                            null_interaction_baseline=-0.15)
-        assert np.allclose(TESTattractive_vector, attractive_vector) 
-        assert np.allclose(TESTrepulsive_vector, repulsive_vector) 
-
+        # compare vectors instance with passed baseline
+        [attractive_vector, repulsive_vector] = all_manipulated[
+            f"{n}_t0_prefactor_baseline"
+        ]
+        TESTattractive_vector, TESTrepulsive_vector = (
+            epsilon_calculation.get_sequence_epsilon_vectors(
+                t, t0, X_local, prefactor=0.25, null_interaction_baseline=-0.15
+            )
+        )
+        assert np.allclose(TESTattractive_vector, attractive_vector)
+        assert np.allclose(TESTrepulsive_vector, repulsive_vector)
 
         # compare vectors instance with no weighting
-        [attractive_vector, repulsive_vector] = all_manipulated[f'{n}_t0_NOWEIGHTING']
-        TESTattractive_vector, TESTrepulsive_vector = epsilon_calculation.get_sequence_epsilon_vectors(t,t0,X_local,
-                                                                            use_charge_weighting=False,
-                                                                            use_aliphatic_weighting=False)
-        assert np.allclose(TESTattractive_vector, attractive_vector) 
+        [attractive_vector, repulsive_vector] = all_manipulated[f"{n}_t0_NOWEIGHTING"]
+        TESTattractive_vector, TESTrepulsive_vector = (
+            epsilon_calculation.get_sequence_epsilon_vectors(
+                t,
+                t0,
+                X_local,
+                use_charge_weighting=False,
+                use_aliphatic_weighting=False,
+            )
+        )
+        assert np.allclose(TESTattractive_vector, attractive_vector)
         assert np.allclose(TESTrepulsive_vector, repulsive_vector)
 
         # check to make sure weighting in working and different from NOWEIGHTING
-        pass 
-
-
-
+        pass

--- a/finches/utils/matrix_manipulation.pyx
+++ b/finches/utils/matrix_manipulation.pyx
@@ -12,7 +12,28 @@ from libc.stdlib cimport rand, srand, RAND_MAX
 @cython.boundscheck(False)
 @cython.cdivision(True)
 def dict2matrix(str seq1, str seq2, dict lookup):
+    """
+    Convert two sequences into a numeric matrix using a nested lookup.
     
+    Parameters
+    ----------
+    seq1 : str
+        First sequence of characters; defines rows of output matrix.
+    seq2 : str
+        Second sequence of characters; defines columns of output matrix.
+    lookup : dict
+        Nested dictionary mapping seq1 char to dict mapping seq2 char to float value.
+    
+    Returns
+    -------
+    numpy.ndarray of shape (len(seq1), len(seq2))
+        Matrix where entry [i,j] = lookup[seq1[i]][seq2[j]].
+    
+    Algorithm
+    ---------
+    1. Preallocate an empty float matrix of shape (len(seq1), len(seq2)).
+    2. Iterate over all index pairs (i,j), assign matrix[i,j] = lookup[seq1[i]][seq2[j]].
+    """
     cdef int r1, r2, l1, l2
 
     l1 = len(seq1)
@@ -30,44 +51,31 @@ def dict2matrix(str seq1, str seq2, dict lookup):
 
 @cython.boundscheck(False)
 @cython.cdivision(True)
-def matrix_scan(double[:,:] w_matrix, int window_size, double null_interaction_baseline):
+cpdef matrix_scan_legacy(double[:,:] w_matrix, int window_size, double null_interaction_baseline):
     """
-    Function that calculates the sliding window epsilon from a given inter-protein matrix.
-    This implementation takes about 8% of the time of our original Python implementation,
-    making it a lot more feasible to use on large matrices.
-
-    Note this returns the indices in protein space, i.e. where the first residue is 1
-
-    Parameters
-    ------------
-    w_matrix : array
-       Inter-protein matrix
-
-    window_size : int
-         Size of the sliding window
-
-    null_interaction_baseline : float
-        Baseline value for null interactions
-
-    Returns
-    --------
-    tuple with three elements:
-
-    everything : array
-       Matrix with sliding window epsilon values
-
+    Compute sliding window epsilon using explicit nested loops.
     
-    seq1_indices : array
-       Indices of the first sequence, starting from 1
-       (i.e. in protein space)
- 
-    seq2_indices : array
-         Indices of the second sequence, starting from 1
-        (i.e. in protein space)
-
+    This legacy implementation performs the following for each window of size w:
+      1. Copy the w*w submatrix from w_matrix.
+      2. Build 'attractive' deviations: values < baseline → (val-baseline), else -baseline.
+      3. Build 'repulsive' deviations: values > baseline → (val-baseline), else -baseline.
+      4. Sum each row of both matrices, normalize by window_size, accumulate total mean.
+      5. Store combined mean deviation as epsilon in `everything[i,j]`.
+    
+    Notes
+    ----------
+    Algorithmic Complexity
+        - O((l1-w+1)*(l2-w+1)*w^2), since each window requires O(w^2) copying and computation.
+    
+    Returns
+    -------
+    everything : 2D numpy.ndarray
+        Sliding window epsilon values for all positions.
+    seq1_indices : 1D numpy.ndarray
+        1-based indices for sequence1 in protein-space.
+    seq2_indices : 1D numpy.ndarray
+        1-based indices for sequence2 in protein-space.
     """
-
-
     # define the variables
     cdef int l1, l2, i, j, start, end, r1, r2;
     cdef double row_sum, total_mean_sum;
@@ -150,22 +158,155 @@ def matrix_scan(double[:,:] w_matrix, int window_size, double null_interaction_b
     return (everything,  seq1_indices, seq2_indices)
 
 
+@cython.cdivision(True)
+cdef double window_sum(cnp.ndarray[double, ndim=2] sat, int top, int left, int bottom, int right):
+    """
+    Retrieve the sum of elements in a rectangular region using a summed-area table.
+    
+    Parameters
+    ----------
+    sat : 2D numpy.ndarray
+        Summed-area table where sat[i,j] = sum of original matrix up to (i,j).
+    top, left, bottom, right : int
+        Inclusive coordinates defining the rectangle to sum.
+    
+    Returns
+    -------
+    double
+        Sum of original elements in rectangle [top:bottom+1, left:right+1].
+    
+    Calculation
+    -----------
+    total = sat[bottom,right]
+            - sat[top-1,right]   if top>0
+            - sat[bottom,left-1] if left>0
+            + sat[top-1,left-1]  if top>0 and left>0
+    """
+    cdef double total = sat[bottom, right]
+    if top > 0:
+        total -= sat[top-1, right]
+    if left > 0:
+        total -= sat[bottom, left-1]
+    if top > 0 and left > 0:
+        total += sat[top-1, left-1]
+    return total
+
+@cython.boundscheck(False)
+@cython.cdivision(True)
+cpdef matrix_scan(double[:,:] w_matrix,
+                            int window_size,
+                            double null_interaction_baseline):
+    """
+    Compute sliding window epsilon efficiently via summed-area table (SAT).
+    Summed-area tables are extensions of prefix sums to 2D matrices. 
+    They are used to quickly compute sums over rectangular regions in O(1) time after an O(l1*l2) preprocessing step.
+    
+    See: https://en.wikipedia.org/wiki/Summed-area_table
+    
+    This optimized algorithm reduces per-window cost from O(w^2) to O(1).
+    Since we use a large window size w=31, this is a significant speedup.
+    
+    Algorithm Overview
+    -------------------
+    The algorithm works as follows:
+        1. Build SAT of w_matrix in O(l1*l2) time:
+            sat[i,j] = w_matrix[i,j] + sat[i,j-1] + sat[i-1,j] - sat[i-1,j-1].
+        2. For each window top-left (i,j):
+            a. Retrieve raw sum via window_sum(sat, i, j, i+w-1, j+w-1) in O(1).
+            b. Compute epsilon = raw/ws - 2 * ws * null_interaction_baseline.
+        3. As before, assemble 1-based protein-space indices.
+
+    Parameters
+    ----------
+    w_matrix : 2D memoryview of double
+        Original interaction matrix.
+    window_size : int
+        Size of the square sliding window.
+    null_interaction_baseline : double
+        Baseline value to normalize interactions.
+    
+    Returns
+    -------
+    everything : 2D numpy.ndarray
+        Matrix of sliding window epsilon values.
+    seq1_indices : 1D numpy.ndarray
+        1-based indices for sequence1.
+    seq2_indices : 1D numpy.ndarray
+        1-based indices for sequence2.
+    """
+    cdef int l1 = w_matrix.shape[0]
+    cdef int l2 = w_matrix.shape[1]
+    cdef int ws = window_size
+    cdef int i, j, r1, r2
+    cdef int out1, out2
+    cdef double raw       
+
+    if l1 < ws or l2 < ws:
+        raise Exception('Window size is larger than matrix size')
+
+    # 1) build one SAT over raw matrix
+    cdef cnp.ndarray[double, ndim=2] w_sat = np.empty((l1, l2), dtype=np.double)
+    for r1 in range(l1):
+        for r2 in range(l2):
+            w_sat[r1, r2] = w_matrix[r1, r2]
+            if r1 > 0:
+                w_sat[r1, r2] += w_sat[r1-1, r2]
+            if r2 > 0:
+                w_sat[r1, r2] += w_sat[r1, r2-1]
+            if r1 > 0 and r2 > 0:
+                # need this to avoid double counting 
+                w_sat[r1, r2] -= w_sat[r1-1, r2-1]
+
+    # 2) slide a single O(1) SAT lookup per window
+    out1 = l1 - ws + 1
+    out2 = l2 - ws + 1
+    cdef cnp.ndarray[double, ndim=2] everything = np.empty((out1, out2), dtype=np.double)
+
+    for i in range(out1):
+        for j in range(out2):
+            # raw window sum
+            raw = window_sum(w_sat,
+                            i, j,
+                            i + ws - 1,
+                            j + ws - 1)
+            # I believe this is the same as the original algorithm, 
+            # but avoids the need to build separate attractive and repulsive matrices. 
+            # I think when garret first presented this algorithm, many of us were confused by the need to have these two matrices. 
+            # as it really felt like there should've been a way to do this with a single matrix.
+            # I can show the algebra why this is equivalent to explicitly constructing separate matrices and catches
+            # an incredibly unlikely edge case in the original implementation where something is equal to the baseline.
+            everything[i, j] = raw/ws - 2.0*ws*null_interaction_baseline
+
+    cdef int start = int((window_size - 1) / 2) + 1
+    cdef int end1 = (l1 - start) + 1
+    cdef int end2 = (l2 - start) + 1
+    seq1_indices = np.arange(start, end1 + 1)
+    seq2_indices = np.arange(start, end2 + 1)
+
+    # Shape checks as in original
+    assert len(seq1_indices) == everything.shape[0]
+    assert len(seq2_indices) == everything.shape[1]
+
+    return everything, seq1_indices, seq2_indices
 
 
 def return_random_array(int n):
     """
-    Function that returns a random array of length n
-
+    Generate a random array of length n using C's rand().
+    
     Parameters
-    ------------
+    ----------
     n : int
-       Length of array
-
+        Desired length of the output array.
+    
     Returns
-    --------
-    arr : array
-       Array of length n with random values
-
+    -------
+    numpy.ndarray
+        1D array of floats in [0,1), each entry = rand()/RAND_MAX.
+    
+    Notes
+    -----
+    Uses the C standard library rand(); not reproducible without seeding via seed_C_rand.
     """
     arr = np.zeros(n)
     for i in range(n):
@@ -177,24 +318,17 @@ def return_random_array(int n):
 #
 cdef seed_C_rand(int seedval):
     """
-    Function that initializes C's rand() function with
-    a seed value. Without this the same seed is used every
-    time..
-
-    Parameters
-    ------------
-    seedval : int
-       Non-negative integer seed
-
-    Returns
-    --------
-    None
-      No return but sets the seed!
+    Seed the C standard library RNG (rand()) for reproducibility.
     
-
+    Parameters
+    ----------
+    seedval : int
+        Non-negative integer seed.
+    
+    Notes
+    -----
+    Calls srand(seedval) from libc.stdlib. Affects subsequent rand() calls.
     """
+    if seedval < 0:
+        raise ValueError("Seed value must be non-negative")
     srand(seedval)
-
-
-        
-        

--- a/setup.py
+++ b/setup.py
@@ -2,30 +2,36 @@
 FINCHES
 Package for computing chemical specificity between disordered regions.
 """
-from setuptools import setup
-from Cython.Build import cythonize
-from setuptools.extension import Extension
-import numpy
+
 import os
 
+import numpy
+from Cython.Build import cythonize
+from setuptools import setup
+from setuptools.extension import Extension
 
 cython_file = os.path.join("finches", "utils", "matrix_manipulation.pyx")
 
-#pyx_path = "finches/utils/matrix_manipulation.pyx"
+# pyx_path = "finches/utils/matrix_manipulation.pyx"
 print("Absolute path:", os.path.abspath(cython_file))
 
 extensions = [
     Extension(
         "finches.utils.matrix_manipulation",
         [cython_file],
-        include_dirs=[numpy.get_include()], 
-    )]
+        include_dirs=[numpy.get_include()],
+        extra_compile_args=[
+            "-O3",
+            "-march=native",
+            "-ffast-math",
+        ],
+    )
+]
 
 
 setup(
-    name='finches',
+    name="finches",
     include_package_data=True,
-    ext_modules = cythonize(extensions, compiler_directives={'language_level' : "3"}),
+    ext_modules=cythonize(extensions, compiler_directives={"language_level": "3"}),
     zip_safe=False,
 )
-    


### PR DESCRIPTION
## Description
This PR attempts to reduce the time complexity of the windowing computation used in the epsilon calculation dramatically by leveraging a summed-area table datastructure to make the window computations constant time after an initial O(m*n) preprocessing stop. For large window sizes - e.g., our default w=31, this results in a ~60-70x speedup. 

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] The finches package lacks good test coverage of the codebase. So it is difficult to make sure there are no regressions here. My implementation passes the one functionally available test, and algebraically I think I didn't screw anything up. Additionally, I compared the two algorithms on random data - which can be found at `becnhmarking/` directory and they are consistent. I think based on all these lines of evidence that it is correct, but I'll have more confidence when things are cleaned up in this codebase and tests are written.